### PR TITLE
Add blocklist versions of the extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-**redditUntranslate** removes language parameters that are automatically added to Reddit URLs, ensuring redirection to original, non-translated content. This extension is particularly useful for users who prefer browsing Reddit in their default language without automatic translation. It also provides an ***optional*** toggle that adds ``-inurl:?tl=`` at the end of every google search to ignore the translated pages.
+**redditUntranslate** removes language parameters that are automatically added to Reddit URLs, ensuring redirection to original, non-translated content. This extension is particularly useful for users who prefer browsing Reddit in their default language without automatic translation. It also provides an ***optional*** toggle that adds `-inurl:?tl=` at the end of every Google search to ignore the translated pages.
 
 ### Repository structure 
 ```text
@@ -92,6 +92,23 @@ The redditUntranslate extension does not collect, store, or transmit any persona
 - 18/04/2025 (2.0) : Rewritten on Manifest V3—now one cross‑browser build with a single queryTransform rule, no background script, no duplicate manifests, and only one permission (declarativeNetRequest).
 - 27/04/2025 (2.1) : Added a Google filter in the form of an optional toggle that filters out translated Reddit pages from Google search results.
 
+## Blocklists
+
+This extension's function can also be achieved by subscribing to the following blocklists for ad blockers and search blockers.
+
+### Ad blockers
+
+Ad blockers such as [uBlock Origin](https://ublockorigin.com) or [Adguard](https://adguard.com) can also remove the `?tl=` parameter from Reddit URLs. Subscribing to this blocklist replicates the main untranslation feature of the full redditUntranslate extension
+
+[Blocklist in AdBlock format.](https://raw.githubusercontent.com/SeidSmatti/redditUntranslate/main/adblock.txt)
+
+### Search blockers (`-inurl:?tl=`)
+
+The [uBlacklist](https://github.com/iorate/ublacklist) browser extension removes sites from search engine results. Subscribing to this blocklist replicates the `-inurl:?tl=` option from the full redditUntranslate extension.
+
+[Blocklist for uBlacklist.](https://raw.githubusercontent.com/SeidSmatti/redditUntranslate/main/ublacklist.txt)
+
+[Click here to subscribe on Chrome.](https://iorate.github.io/ublacklist/subscribe?name=redditUntranslate&url=https://raw.githubusercontent.com/SeidSmatti/redditUntranslate/main/ublacklist.txt)  (This automatic subscription link is only compatible with Chrome, you have to add it by yourself on other browsers!)
 
 ## License
 

--- a/adblock.txt
+++ b/adblock.txt
@@ -3,4 +3,4 @@
 ! Expires: 7 days
 ! Homepage: https://github.com/SeidSmatti/redditUntranslate
 
-$removeparam=tl,domain=reddit.com|reddittorjg6rue252oqsxryoxengawnmo46qy4kyii5wtqnwfj4ooad.onion
+$removeparam=tl,domain=reddit.com

--- a/adblock.txt
+++ b/adblock.txt
@@ -1,0 +1,6 @@
+! Title: redditUntranslate
+! Description: Removes language parameters that are automatically added to Reddit URLs, ensuring redirection to original, non-translated content.
+! Expires: 7 days
+! Homepage: https://github.com/SeidSmatti/redditUntranslate
+
+$removeparam=tl,domain=reddit.com|reddittorjg6rue252oqsxryoxengawnmo46qy4kyii5wtqnwfj4ooad.onion

--- a/ublacklist.txt
+++ b/ublacklist.txt
@@ -5,4 +5,3 @@ homepage: https://github.com/SeidSmatti/redditUntranslate
 ---
 
 *://*.reddit.com/*?tl=*
-*://*.reddittorjg6rue252oqsxryoxengawnmo46qy4kyii5wtqnwfj4ooad.onion/*?tl=*

--- a/ublacklist.txt
+++ b/ublacklist.txt
@@ -1,0 +1,8 @@
+---
+name: redditUntranslate
+description: Removes translated Reddit pages from search results.
+homepage: https://github.com/SeidSmatti/redditUntranslate
+---
+
+*://*.reddit.com/*?tl=*
+*://*.reddittorjg6rue252oqsxryoxengawnmo46qy4kyii5wtqnwfj4ooad.onion/*?tl=*


### PR DESCRIPTION
Replicating the features of the browser extension with adblock and ublacklist lists.

I love this project, but I also want to install as few extensions as possible so I did this! I could host this myself, but I believe this is the right home for these lists as they have the same goal as this project and don't require a lot of maintenance.

Inspired by the [Legitimate URL shortener list](https://github.com/DandelionSprout/adfilt/blob/master/LegitimateURLShortener.txt) that replicates the [ClearURLs addon](https://github.com/ClearURLs/Addon) in a blocklist format and [a reddit post](https://www.reddit.com/r/france/comments/1m5ctry/guide_comment_d%C3%A9sactiver_la_traduction/) giving the right filter to do the untranslating.